### PR TITLE
Edit Gemfile to reflect new repo name.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby RUBY_VERSION
 
 gem "decidim", "0.22.0"
 gem "decidim-proposals", "0.22.0"
-gem "decidim-liquidvoting", path: "../decidim-liquidvoting"
+gem "decidim-liquidvoting", path: "../decidim-module-liquidvoting"
 
 gem "bootsnap", "~> 1.4.6"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../decidim-liquidvoting
+  remote: ../decidim-module-liquidvoting
   specs:
     decidim-liquidvoting (0.1)
       decidim-core (= 0.22.0)


### PR DESCRIPTION
Gemfile edit, following rename of repo. `decidim-liquidvoting` to `decidim-module-liquidvoting`

Gemfile now refers to path: `../decidim-module-liquidvoting`.
This also caused `Gemfile.lock` to update.

Confirmed working by `bundle install` + run API server + `bin/rails s` (actually `sudo bin/rails s --port=80` to sidestep issue with `localhost:3000` in url). Created participatory process + added LV component + proposal comnponent, then created proposal & tested our new UI functionality is working.