### PR TITLE
Match current version of decidim-liquidvoting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../decidim-module-liquidvoting
   specs:
-    decidim-liquidvoting (0.1)
+    decidim-liquidvoting (0.22.0)
       decidim-core (= 0.22.0)
       decidim-proposals (= 0.22.0)
       graphql-client (~> 0.16.0)


### PR DESCRIPTION
Our module "gem" now tracks the Decidim gem versions we're using.