### PR TITLE
Bump rexml to remedy CVE-2021-28965

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -669,7 +669,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)


### PR DESCRIPTION
While Dependabot did not raise an alert in this repo, it did in `decidim-module-liquidvoting`, and we should have the same issue here, so I'm fixing.

Related to Issue liquidvotingio/decidim-module-liquidvoting#111
Related to PR liquidvotingio/decidim-module-liquidvoting#112