### PR TITLE
Remove proposals gem from Gemfile - not needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", "0.24.0"
-gem "decidim-assemblies", "0.24.0"
-gem "decidim-proposals", "0.24.0"
 gem "decidim-liquidvoting", path: "../decidim-module-liquidvoting"
 
 gem "bootsnap", "~> 1.4.6"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", "0.24.0"
+gem "decidim-assemblies", "0.24.0"
 gem "decidim-proposals", "0.24.0"
 gem "decidim-liquidvoting", path: "../decidim-module-liquidvoting"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -829,6 +829,7 @@ DEPENDENCIES
   bootsnap (~> 1.4.6)
   byebug (~> 11.0)
   decidim (= 0.24.0)
+  decidim-assemblies (= 0.24.0)
   decidim-dev (= 0.24.0)
   decidim-liquidvoting!
   decidim-proposals (= 0.24.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -829,10 +829,8 @@ DEPENDENCIES
   bootsnap (~> 1.4.6)
   byebug (~> 11.0)
   decidim (= 0.24.0)
-  decidim-assemblies (= 0.24.0)
   decidim-dev (= 0.24.0)
   decidim-liquidvoting!
-  decidim-proposals (= 0.24.0)
   faker (~> 2.14)
   letter_opener_web (~> 1.3)
   listen (~> 3.1)


### PR DESCRIPTION
The `decidim-assemblies` gem was already a dependency in the Gemfile.lock, unsure adding it to the Gemfile changes anything but it does make it explicit, and explicitly the Decidim version we want.